### PR TITLE
fix: set `config.testMatches` value as empty array if tries to set in…

### DIFF
--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -71,7 +71,9 @@ export class Config implements IConfigOptions {
     }
 
     if (config.testMatches && (!this.testMatches || this.testMatches.length === 0 || forceUpdate)) {
-      this.testMatches = config.testMatches;
+      this.testMatches = this.testMatches = Array.isArray(config.testMatches)
+        ? config.testMatches
+        : [];
     }
   }
 }

--- a/tests/common/config.test.ts
+++ b/tests/common/config.test.ts
@@ -1,6 +1,7 @@
 import { IConfigOptions } from "../../src/types";
 import { Config } from "../../src/common/config";
 import { DEFAULT_TEST_TIMEOUT } from "../../src/consts";
+import { config } from "process";
 
 describe("testing config", () => {
   it("should set all values to configs", () => {
@@ -15,6 +16,13 @@ describe("testing config", () => {
     const config = new Config();
     config.setConfigs(configOptions);
     expect(config).toEqual({ ...configOptions, timeOut: DEFAULT_TEST_TIMEOUT });
+  });
+
+  it("should not allow define testMatches as object {}", () => {
+    const config = new Config();
+    // @ts-ignore
+    config.setConfigs({ testMatches: {} });
+    expect(config.testMatches).toEqual([]);
   });
 
   it("should force update settings", () => {


### PR DESCRIPTION
…valid value to it (null, object etc)