### PR TITLE
fix(reader): support configs with .cjs extension

### DIFF
--- a/src/core/reader.ts
+++ b/src/core/reader.ts
@@ -126,7 +126,7 @@ export class Reader {
 
     if (fileExt === ".json") {
       return JSON.parse(fs.readFileSync(filePath).toString());
-    } else if (fileExt === ".js" || fileExt === ".ts") {
+    } else if (fileExt === ".cjs" || fileExt === ".js" || fileExt === ".ts") {
       return require(filePath);
     } else {
       throw new FileError(`Extension '${fileExt}' is not supported`);

--- a/tests/core/reader.test.ts
+++ b/tests/core/reader.test.ts
@@ -31,11 +31,21 @@ describe("reader class", () => {
       beforeEach(() => {
         jest.resetAllMocks();
       });
-      it("should read configs from configFilePath", () => {
+      it("should read JS configs from configFilePath", () => {
         const spy = jest.spyOn(fs, "readFileSync").mockReturnValue(null);
         runtime.configFilePath = path.resolve(
           process.cwd(),
           "tests/mocks/jsconfig/corde.config.js",
+        );
+        expect(reader.loadConfig()).toEqual(conf);
+        spy.mockReset();
+      });
+
+      it("should read CJS configs from configFilePath", () => {
+        const spy = jest.spyOn(fs, "readFileSync").mockReturnValue(null);
+        runtime.configFilePath = path.resolve(
+          process.cwd(),
+          "tests/mocks/cjsconfig/corde.config.cjs",
         );
         expect(reader.loadConfig()).toEqual(conf);
         spy.mockReset();

--- a/tests/mocks/cjsconfig/corde.config.cjs
+++ b/tests/mocks/cjsconfig/corde.config.cjs
@@ -1,0 +1,9 @@
+module.exports = {
+  botPrefix: "",
+  botTestId: "",
+  channelId: "",
+  cordeBotToken: "",
+  guildId: "",
+  testMatches: [""],
+  timeout: 5000,
+};


### PR DESCRIPTION
Not ESM support, but a solid workaround.

Fixes #1428.